### PR TITLE
add --config parameter to allow specifying a configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ moh2006s@hotmail.com
  
 # GoLDAP Configuration
 
+A configuration example is given in the config.json file.
 
-
+## LDAP related items in the "ldap" dictionary
 
 `ldap_server =` 'ldap://ldap_server_IP'  
 
@@ -27,53 +28,40 @@ Active directory credential
 `pw =` 'password'  
 
 
-`base_dn =`  'Location of the container'  
+`base_dn =`  'Location of the container'
 
 >  The Base DN setting specifies the root for searches in the Active
 > Directory, e.g, if your domain name is "example.local". Convert it
-> into  "dc=ISL,dc=local". Assuming your  targeted users are in the
+> into  "dc=example,dc=local". Assuming your  targeted users are in the
 > default location, the OU named "Users", it will be converted  to
 > "ou=users". the final search for users will be
-> "ou=users,dc=ISL,dc=local". To find the right container consult you
+> "ou=users,dc=example,dc=local". To find the right container consult you
 > system admin. Read more about "[LDAP data Interchange
 > Format](http://en.wikipedia.org/wiki/LDAP_Data_Interchange_Format)"
 
-`col_names =` 'Email, First Name, Last Name,position'    
+`attrs =`    'A list of the user attributes to fetch from LDAP'
 
- Unfortunately, we cannot control the order of the columns in LDAP, SO, based on my testing it usually comes in this order, change the order if yous is different.  
+## Mapping between LDAP attributes and GoPhish fields are in the "ldap_to_gophish_mapping" dictionary:
 
-Gophish Configuration  
+Note: The keys are the GoPhish fields, and should always be the same, the values are the respective
+LDAP attributes, and should match the attrs given in the "ldap" dictionary.
+
+## Gophish configuration items in the "gophish" dictionary:
+
 `gophish_server =` 'localhost'  
 `gophish_port =` '3333'  
 `gophish_api_key =` 'api_key'  
 
 `group_name =` "gophish _group_name"  
 
-Put the name of the group you want to create or  modify.  
+Put the name of the group you want to create or modify.  
  
-> Very Important: if you want to modify a group and you specified its ID
-> in the variable below, you have to put its name above as well,
-> otherwise, it will modify the name of the group. Basically, the only 
-> identifier for a group is its ID not its name.
-
-`update_group = 0`  
-
-If you want to modify an existing group, put its ID int this variable as integer, otherwise put 0 to create a new group with the name specified in the "group_name" variable.  
-
-> To get your current groups ID, request this endpoint in your browser.
-
-    https://gophish_ip:3333/api/groups/summary?api_key=your_api_key
-
-
 # GoLDAP Stages
 
 1. Performing LDAP query.
-2. Reformatting the result of the query since it comes as a list of sub-lists. The second sub-list of every list  contains a dictionary that stores every value in a list of single value. I took sometime to realize that :D.
-3.  Write users and their attributes in CSV format and export it as a CSV file.
-4. Rename the colomns names in the CSV file to match Gophish naming, e.g "Givenname" will be "First Name".
-5. Post the CSV file to the Gophish API "Import Group" to get them in JSON format 
-6. Post (if new group) or Put (if existing group) the JSON got from the API "Import Group" to the API "Create Group".
-7. or mod
+2. Transform the LDAP result into a dictionary ready to upload to GoPhish.
+3. Check if a group with the given name already exists.
+4. Post (if new group) or Put (if existing group) the JSON to the API "Create Group".
 
 # Usage
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,27 @@
+{
+  "ldap": {
+    "server": "ldaps://ldap.example.com",
+    "username": "LDAP BIND USERNAME",
+    "password": "LDAP BIND PASSWORD",
+    "attrs": [
+      "mail",
+      "givenname",
+      "sn",
+      "title"
+    ],
+    "base_dn": "OU=Accounts,DC=example,DC=com",
+    "filter": "(objectClass=person)"
+  },
+  "ldap_to_gophish_mapping": {
+    "first_name": "givenName",
+    "last_name": "sn",
+    "email": "mail",
+    "position": "title"
+  },
+  "gophish": {
+    "server": "localhost",
+    "port": "3333",
+    "api_key": "GOPHISH API KEY",
+    "group_name": "GROUP NAME IN GOPHISH",
+  }
+}


### PR DESCRIPTION
Allowing to specify a configuration file allows multiple cron jobs, or a wrapper around the script to create a number of groups in GoPhish based on different LDAP filters.

The --config parameter defaults to the given config.json.

Updated the documentation to reflect the changes, and document the config file parameters.

While there, as it seems easier to handle, I changed the way GoLDAP works. It doesn't create an 
intermediary CSV file anymore. It uses the ldap_to_gophish_mapping to create a JSON blob from the
attributes retrieved from LDAP. It then checks the GoPhish API if a group with the same name already
exists, if not, it's POSTing to create a new group, otherwise PUTing to update the existing group.

Updated README.md to reflect the changes.

Hope you like it, let me know if I shall change/update some bits here or there.
If you don't like it, feel free to dismiss the MR.
